### PR TITLE
Typo: originalPaths --> originalPath

### DIFF
--- a/pinCTF.py
+++ b/pinCTF.py
@@ -353,7 +353,7 @@ def pinIter(pin,library,binary,seed,variable_range,arg=False,start=0,threading=F
                     print("[-] Unable to slot value into seed string. Likely 0 delta from other inputs")
                     print("[~] Switching to other favored paths")
                     print("Removing {}".format(originalPath))
-                    favoredPaths.remove(originalPaths)
+                    favoredPaths.remove(originalPath)
                     if len(favoredPaths) > 1:
                         print("Multiple FavoredPaths : {}".format(favoredPaths))
                     favored = False


### PR DESCRIPTION
flake8 testing of https://github.com/ChrisTheCoolHut/PinCTF on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pinCTF.py:356:41: F821 undefined name 'originalPaths'
                    favoredPaths.remove(originalPaths)
                                        ^
1     F821 undefined name 'originalPaths'
```