### PR TITLE
Change first line to env

### DIFF
--- a/pinCTF.py
+++ b/pinCTF.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import os
 import sys


### PR DESCRIPTION
better portability across various platforms using /usr/bin/env python instead of /usr/bin/python3