### PR TITLE
Use absolute pinLibraryLocation path

### DIFF
--- a/pinCTF.py
+++ b/pinCTF.py
@@ -74,6 +74,7 @@ def main():
         pinLocation = args.pinLocation
     if args.pinLibraryLocation:
         libraryLocation = args.pinLibraryLocation
+        libraryLocation = os.path.abspath(libraryLocation)
     if args.count:
         count = int(args.count)
     if args.seedLength:


### PR DESCRIPTION
Use absolute path in libraryLocation so pin can find the library when dir change to pin_{}.